### PR TITLE
Install unzip instead of zip

### DIFF
--- a/templates/cloud-init-userdata.yaml
+++ b/templates/cloud-init-userdata.yaml
@@ -17,5 +17,5 @@ runcmd:
   - EBS_AUTOSCALE_VERSION=$(curl --silent "https://api.github.com/repos/awslabs/amazon-ebs-autoscale/releases/latest" | jq -r .tag_name)
   - cd /opt && git clone https://github.com/awslabs/amazon-ebs-autoscale.git
   - cd /opt/amazon-ebs-autoscale && git checkout $EBS_AUTOSCALE_VERSION
-  - scratchPath=$(jq '.mountpoint' config/ebs-autoscale.json)
+  - scratchPath=$(jq -r '.mountpoint' config/ebs-autoscale.json)
   - sh /opt/amazon-ebs-autoscale/install.sh $scratchPath /dev/sdc 2>&1 > /var/log/ebs-autoscale-install.log

--- a/templates/cloud-init-userdata.yaml
+++ b/templates/cloud-init-userdata.yaml
@@ -17,4 +17,5 @@ runcmd:
   - EBS_AUTOSCALE_VERSION=$(curl --silent "https://api.github.com/repos/awslabs/amazon-ebs-autoscale/releases/latest" | jq -r .tag_name)
   - cd /opt && git clone https://github.com/awslabs/amazon-ebs-autoscale.git
   - cd /opt/amazon-ebs-autoscale && git checkout $EBS_AUTOSCALE_VERSION
+  - scratchPath=$(jq '.mountpoint' config/ebs-autoscale.json)
   - sh /opt/amazon-ebs-autoscale/install.sh $scratchPath /dev/sdc 2>&1 > /var/log/ebs-autoscale-install.log

--- a/templates/cloud-init-userdata.yaml
+++ b/templates/cloud-init-userdata.yaml
@@ -8,7 +8,7 @@ packages:
   - sed
   - wget
   - git
-  - zip
+  - unzip
 
 
 runcmd:


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
2nd step in templates/cloud-init-userdata.yaml is to unzip awscliv2.zip, however unzip is never installed.  Instead zip is installed which is the wrong package.  This was probably never caught because the AWS AMI already has awscli installed, so if this step failed, it wouldn't matter much.

This fix installs unzip.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
