### PR TITLE
Improvements to threshold calculation and ability to cope with API throttling 

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -233,6 +233,7 @@ function create_and_attach_volume() {
 
     logthis "created volume: $volume_id [ $volume_opts ]"
 
+    sleep 10
     aws ec2 wait volume-available --region $region --volume-ids $volume_id
     logthis "volume $volume_id available"
 
@@ -240,6 +241,8 @@ function create_and_attach_volume() {
     # cost efficient.  If attachment fails, delete the volume.
     set +e
     logthis "attaching volume $volume_id"
+
+    sleep 1
     aws ec2 attach-volume \
         --region $region \
         --device $device \

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -161,18 +161,21 @@ function create_and_attach_volume() {
     local availability_zone=$(get_metadata placement/availability-zone)
     local region=${availability_zone%?}
 
+    sleep 1
     local attached_volumes=$(
         aws ec2 describe-volumes \
             --region $region \
             --filters "Name=attachment.instance-id,Values=$instance_id"
     )
 
+    sleep 1
     local created_volumes=$(
         aws ec2 describe-volumes \
             --region $region \
             --filters "Name=tag:source-instance,Values=$instance_id"
     )
 
+    sleep 1
     local total_created_size=$(
         aws ec2 describe-volumes \
             --region $region \

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -164,7 +164,7 @@ function create_and_attach_volume() {
     local max_attempts=10
     local attached_volumes=""
 
-    for i in {1..$max_attempts} ; do
+    for i in $(eval echo "{0..$max_attempts}") ; do
         attached_volumes=$(
           aws ec2 describe-volumes \
             --region $region \
@@ -181,7 +181,7 @@ function create_and_attach_volume() {
     done
 
     local created_volumes=""
-    for i in {1..$max_attempts} ; do
+    for i in $(eval echo "{0..$max_attempts}") ; do
         created_volumes=$(
             aws ec2 describe-volumes \
                 --region $region \
@@ -198,7 +198,7 @@ function create_and_attach_volume() {
     done
 
     local total_created_size=""
-    for i in {1..$max_attempts} ; do
+    for i in $(eval echo "{0..$max_attempts}") ; do
         total_created_size=$(
             aws ec2 describe-volumes \
                 --region $region \
@@ -248,7 +248,7 @@ function create_and_attach_volume() {
     local timestamp=$(date "+%F %T UTC%z")  # YYYY-mm-dd HH:MM:SS UTC+0000
 
     local volume=""
-    for i in {1..$max_attempts} ; do
+    for i in $(eval echo "{0..$max_attempts}") ; do
       local volume=$(\
           aws ec2 create-volume \
               --region $region \

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -216,8 +216,6 @@ function create_and_attach_volume() {
         sleep $(( 2 ** i ))
     done
 
-    local
-
     # check how much EBS storage this instance has created
     if [ "$total_created_size" -ge "$MAX_TOTAL_EBS_SIZE" ]; then
         error "maximum total ebs volume size reached ($MAX_TOTAL_EBS_SIZE)"

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -161,28 +161,62 @@ function create_and_attach_volume() {
     local availability_zone=$(get_metadata placement/availability-zone)
     local region=${availability_zone%?}
 
-    sleep 1
-    local attached_volumes=$(
-        aws ec2 describe-volumes \
+    local max_attempts=10
+    local attached_volumes=""
+
+    for i in {1..$max_attempts} ; do
+        attached_volumes=$(
+          aws ec2 describe-volumes \
             --region $region \
             --filters "Name=attachment.instance-id,Values=$instance_id"
-    )
+        )
 
-    sleep 1
-    local created_volumes=$(
-        aws ec2 describe-volumes \
-            --region $region \
-            --filters "Name=tag:source-instance,Values=$instance_id"
-    )
+        if [ $? -eq 0 ]; then
+             break
+        elif [ $i -eq $max_attempts ]; then
+            logthis "Could not determine the number of attached_volumes after $i attempts. Last response was: $attached_volumes"
+            break
+        fi
+        sleep $(( 2 ** i ))
+    done
 
-    sleep 1
-    local total_created_size=$(
-        aws ec2 describe-volumes \
-            --region $region \
-            --filters "Name=tag:source-instance,Values=$instance_id" \
-            --query 'sum(Volumes[].Size)' \
-            --output text
-    )
+    local created_volumes=""
+    for i in {1..$max_attempts} ; do
+        created_volumes=$(
+            aws ec2 describe-volumes \
+                --region $region \
+                --filters "Name=tag:source-instance,Values=$instance_id"
+        )
+
+        if [ $? -eq 0 ]; then
+             break
+        elif [ $i -eq $max_attempts ]; then
+            logthis "Could not determine the number of created_volumes after $i attempts. Last response was: $created_volumes"
+            break
+        fi
+        sleep $(( 2 ** i ))
+    done
+
+    local total_created_size=""
+    for i in {1..$max_attempts} ; do
+        total_created_size=$(
+            aws ec2 describe-volumes \
+                --region $region \
+                --filters "Name=tag:source-instance,Values=$instance_id" \
+                --query 'sum(Volumes[].Size)' \
+                --output text
+        )
+
+        if [ $? -eq 0 ]; then
+             break
+        elif [ $i -eq $max_attempts ]; then
+            logthis "Could not determine the total_created_size after $i attempts. Last response was: $total_created_size"
+            break
+        fi
+        sleep $(( 2 ** i ))
+    done
+
+    local
 
     # check how much EBS storage this instance has created
     if [ "$total_created_size" -ge "$MAX_TOTAL_EBS_SIZE" ]; then
@@ -212,14 +246,27 @@ function create_and_attach_volume() {
     if [ "$TYPE" == "io1" ]; then volume_opts="$volume_opts --iops $IOPS"; fi
     if [ "$ENCRYPTED" == "1" ]; then volume_opts="$volume_opts --encrypted"; fi
     local timestamp=$(date "+%F %T UTC%z")  # YYYY-mm-dd HH:MM:SS UTC+0000
-    local volume=$(\
-        aws ec2 create-volume \
-            --region $region \
-            --availability-zone $availability_zone \
-            $volume_opts \
-            --tag-specification "ResourceType=volume,Tags=[{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]" \
-        2> $tmpfile
-    )
+
+    local volume=""
+    for i in {1..$max_attempts} ; do
+      local volume=$(\
+          aws ec2 create-volume \
+              --region $region \
+              --availability-zone $availability_zone \
+              $volume_opts \
+              --tag-specification "ResourceType=volume,Tags=[{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]" \
+          2> $tmpfile
+      )
+
+      if [ $? -eq 0 ]; then
+           break
+      elif [ $i -eq $max_attempts ]; then
+          logthis "Could not create a volume after $i attempts. Last response was: $volume"
+          break
+      fi
+      sleep $(( 2 ** i ))
+    done
+
     local volume_id=`echo $volume | jq -r '.VolumeId'`
 
     if [ -z "$volume_id" ]; then
@@ -233,9 +280,13 @@ function create_and_attach_volume() {
 
     logthis "created volume: $volume_id [ $volume_opts ]"
 
-    sleep 10
-    aws ec2 wait volume-available --region $region --volume-ids $volume_id
-    logthis "volume $volume_id available"
+    # In theory this shouldn't need to loop as aws ec2 wait will retry but I have seen it exceed request limits
+    for i in {1..3} ; do
+       if aws ec2 wait volume-available --region $region --volume-ids $volume_id; then
+         logthis "volume $volume_id available"
+         break
+       fi
+    done
 
     # Need to assure that the created volume is successfully attached to be
     # cost efficient.  If attachment fails, delete the volume.

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -70,10 +70,10 @@ get_num_devices() {
       attached_volumes=$(
       aws ec2 describe-volumes \
           --region $AWS_REGION \
-          --filters Name=attachment.instance-id,Values=$INSTANCE_ID, Name=tag-key,Values=$tag
-       sleep $sleep_time
-       sleep_time=${sleep_time * 2 }
-  )
+          --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$tag
+       )
+      sleep $sleep_time
+      sleep_time=${sleep_time * 2 }
   done
 
   echo "`echo $attached_volumes | jq '.Volumes | length'`"

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -63,7 +63,6 @@ get_num_devices() {
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
   local attached_volumes=""
-  local attempt=0
   local max_attempts=10
 
   # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
@@ -83,7 +82,8 @@ get_num_devices() {
       fi
 
       if [ $i -eq $max_attempts ] ; then
-        logthis "Could not determine the number of attached_volumes after $attempt attempts. Last response was: $attached_volumes_response"
+        logthis "Could not determine the number of attached_volumes after $i attempts. Last response was: $attached_volumes_response"
+        break
       fi
 
       sleep $(( 2 ** i ))

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -56,11 +56,15 @@ until [ -d "${MOUNTPOINT}" ]; do
 done
 
 get_num_devices() {
-  # determine the number of attached devices on this instance
+  #This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script
+  tag=amazon-ebs-autoscale-creation-time
+
+  # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
+  # excluded as they aren't relevant to autoscaling
   local attached_volumes=$(
       aws ec2 describe-volumes \
           --region $AWS_REGION \
-          --filters Name=attachment.instance-id,Values=$INSTANCE_ID
+          --filters Name=attachment.instance-id,Values=$INSTANCE_ID, Name=tag-key,Values=$tag
   )
 
   echo "`echo $attached_volumes | jq '.Volumes | length'`"

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -56,7 +56,8 @@ until [ -d "${MOUNTPOINT}" ]; do
 done
 
 get_num_devices() {
-  #This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script
+  # This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script it's presence indicates
+  # a device that has been added by auto-expansion rather than an EBS volume attached for other reasons or at startup.
   TAG=amazon-ebs-autoscale-creation-time
 
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -57,7 +57,7 @@ done
 
 get_num_devices() {
   #This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script
-  tag=amazon-ebs-autoscale-creation-time
+  TAG=amazon-ebs-autoscale-creation-time
 
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
@@ -68,15 +68,17 @@ get_num_devices() {
   # eventually getting a usable value.
   until [ $attached_volumes -ge 0 ] 2> /dev/null ; do
       attached_volumes=$(
-      aws ec2 describe-volumes \
-          --region $AWS_REGION \
-          --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$tag
+        aws ec2 describe-volumes \
+            --region $AWS_REGION \
+            --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$TAG
        )
       sleep $sleep_time
       sleep_time=${sleep_time * 2 }
+
+      $attached_volumes=$(echo $attached_volumes | jq '.Volumes | length'`)
   done
 
-  echo "`echo $attached_volumes | jq '.Volumes | length'`"
+  echo attached_volumes
 }
 
 calc_threshold() {

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -73,12 +73,12 @@ get_num_devices() {
             --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$TAG
        )
       sleep $sleep_time
-      sleep_time=${sleep_time * 2 }
+      sleep_time=$(( sleep_time * 2 ))
 
-      $attached_volumes=$(echo $attached_volumes | jq '.Volumes | length'`)
+      attached_volumes=$(echo "$attached_volumes" | jq '.Volumes | length')
   done
 
-  echo $attached_volumes
+  echo "$attached_volumes"
 }
 
 calc_threshold() {

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -78,7 +78,7 @@ get_num_devices() {
       $attached_volumes=$(echo $attached_volumes | jq '.Volumes | length'`)
   done
 
-  echo attached_volumes
+  echo $attached_volumes
 }
 
 calc_threshold() {

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -63,11 +63,11 @@ get_num_devices() {
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
   local attached_volumes=""
-  local max_attempts=10
+  local max_attempts=5
 
   # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
   # eventually getting a usable value. The >= 0 test is really a test that we got an integer response
-  for i in {1..$max_attempts} ; do
+  for i in $(eval echo "{0..$max_attempts}") ; do
       local attached_volumes_response=""
 
       attached_volumes_response=$(

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -61,11 +61,20 @@ get_num_devices() {
 
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
-  local attached_volumes=$(
+  local attached_volumes=""
+  local sleep_time=1
+
+  # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
+  # eventually getting a usable value.
+  until [ $attached_volumes -ge 0 ] 2> /dev/null ; do
+      attached_volumes=$(
       aws ec2 describe-volumes \
           --region $AWS_REGION \
           --filters Name=attachment.instance-id,Values=$INSTANCE_ID, Name=tag-key,Values=$tag
+       sleep $sleep_time
+       sleep_time=${sleep_time * 2 }
   )
+  done
 
   echo "`echo $attached_volumes | jq '.Volumes | length'`"
 }

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -62,20 +62,30 @@ get_num_devices() {
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
   local attached_volumes=""
-  local sleep_time=1
+  local attempt=0
+  local max_attempts=10
 
   # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
-  # eventually getting a usable value.
-  until [ $attached_volumes -ge 0 ] 2> /dev/null ; do
-      attached_volumes=$(
+  # eventually getting a usable value. The >= 0 test is really a test that we got an integer response
+  for i in {1..$max_attempts} ; do
+      local attached_volumes_response=""
+
+      attached_volumes_response=$(
         aws ec2 describe-volumes \
             --region $AWS_REGION \
             --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$TAG
        )
-      sleep $sleep_time
-      sleep_time=$(( sleep_time * 2 ))
 
-      attached_volumes=$(echo "$attached_volumes" | jq '.Volumes | length')
+      attached_volumes=$(echo "$attached_volumes_response" | jq '.Volumes | length')
+      if [ "$attached_volumes" -ge 0 ]; then
+          break
+      fi
+
+      if [ $i -eq $max_attempts ] ; then
+        logthis "Could not determine the number of attached_volumes after $attempt attempts. Last response was: $attached_volumes_response"
+      fi
+
+      sleep $(( 2 ** i ))
   done
 
   echo "$attached_volumes"


### PR DESCRIPTION

*Description of changes:*

There are two changes. The first is relatively straightforward. I have changed the `get_num_devices` function to filter to devices added by the script. The reason for this is we have EC2s that deploy with several disks already attached but only one of them will be autoscaling. This means that the thresholds for triggering scaling are too low.

The second change is because I observed that in accounts with standard API request limits the scripts could easily result in request limits being exceeded which would in ~50% of cases result in the `install` script failing or the allocation of the disk failing. It seems that the retry behavior of the AWS CLI doesn't prevent these errors which might be a CLI bug?

Although I could have increase the `DETECTION_INTERVAL` I wanted to keep it very small to respond quickly when disks fill rapidly. Instead I have put most of the CLI calls into `for` loops that exponentially back off to give the request token bucket time to recover. In testing this works well and doesn't require anyone using the script to increase their limits.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
