### PR TITLE
limit Describevolume requests

### DIFF
--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -97,7 +97,7 @@ calc_threshold() {
   # calculates percent utilization threshold for adding additional ebs volumes
   # as more ebs volumes are added, the threshold level increases
 
-  local num_devices=$(get_num_devices)
+  local num_devices=$1
   local threshold=50
 
   if [ "$num_devices" -ge "4" ] && [ "$num_devices" -le "6" ]; then
@@ -116,32 +116,32 @@ calc_threshold() {
 calc_new_size() {
   # calculates the size to use for new ebs volumes to expand space
   # new volume sizes increase as the number of attached volumes increase
-  
-  local num_devices=$(get_num_devices)
+  local num_devices=$1
+  #local num_devices=$(get_num_devices)
   local new_size=150
 
   if [ "$num_devices" -ge "4" ] && [ "$num_devices" -le "6" ]; then
     if [ "$MAX_EBS_VOLUME_SIZE" -ge "299" ]; then
-      new_size=300 
-    else 
+      new_size=300
+    else
       new_size=$MAX_EBS_VOLUME_SIZE
     fi
   elif [ "$num_devices" -gt "6" ] && [ "$num_devices" -le "10" ]; then
     if [ "$MAX_EBS_VOLUME_SIZE" -ge "999" ]; then
-      new_size=1000 
-    else 
+      new_size=1000
+    else
       new_size=$MAX_EBS_VOLUME_SIZE
     fi
   elif [ "$num_devices" -gt "10" ]; then
     if [ "$MAX_EBS_VOLUME_SIZE" -ge "1499" ]; then
-      new_size=1500 
-    else 
+      new_size=1500
+    else
       new_size=$MAX_EBS_VOLUME_SIZE
     fi
   else
     if [ "$MAX_EBS_VOLUME_SIZE" -ge "149" ]; then
-      new_size=150 
-    else 
+      new_size=150
+    else
       new_size=$MAX_EBS_VOLUME_SIZE
     fi
   fi
@@ -150,7 +150,8 @@ calc_new_size() {
 }
 
 add_space () {
-  local num_devices=$(get_num_devices)
+  #local num_devices=$(get_num_devices)
+  local num_devices=$1
   if [ "${num_devices}" -ge "$MAX_EBS_VOLUME_COUNT" ]; then
     logthis "No more volumes can be safely added."
     return 0
@@ -158,7 +159,7 @@ add_space () {
 
   local curr_size=$(df -BG ${MOUNTPOINT} | grep ${MOUNTPOINT} | awk '{print $2} ' | cut -d'G' -f1)
   if [ "${curr_size}" -lt "$MAX_LOGICAL_VOLUME_SIZE" ]; then
-    local vol_size=$(calc_new_size)
+    local vol_size=$(calc_new_size ${num_devices})
     logthis "Extending logical volume ${MOUNTPOINT} by ${vol_size}GB"
 
     DEVICE=$(${BASEDIR}/create-ebs-volume --size ${vol_size} --max-attached-volumes ${MAX_EBS_VOLUME_COUNT})
@@ -198,25 +199,29 @@ LOG_COUNT=$LOG_INTERVAL
 # time in seconds between event loops
 # keep this low so that rapid increases in utilization are detected
 DETECTION_INTERVAL=$(get_config_value .detection_interval)
-
-THRESHOLD=$(calc_threshold)
+# get the number of devices once when the script first starts
+NUM_DEVICES=$(get_num_devices)
+THRESHOLD=$(calc_threshold "${NUM_DEVICES}")
 while true; do
-  NUM_DEVICES=$(get_num_devices)
+
   STATS=$(df -BG  ${MOUNTPOINT} | grep -v Filesystem)
   TOTAL_SIZE=$(echo ${STATS} | awk '{print $2}')
   USED=$(echo ${STATS} | awk '{print $3}')
   AVAILABLE=$(echo ${STATS} | awk '{print $4}')
   PCT_UTILIZATION=$(echo ${STATS} | awk '{print $5}' | cut -d"%" -f1 -)
   if  [ $PCT_UTILIZATION -ge "${THRESHOLD}" ]; then
+    # get number of devices only when we need to add more space
+  	NUM_DEVICES=$(get_num_devices)
     logthis "LOW DISK (${PCT_UTILIZATION}%): Adding more."
-    add_space
+    add_space "$NUM_DEVICES"
+	NUM_DEVICES=$(expr $NUM_DEVICES + 1 )
+    THRESHOLD=$(calc_threshold "$NUM_DEVICES")
     LOG_COUNT=LOG_INTERVAL
   fi
   if [ "${LOG_COUNT}" -ge "${LOG_INTERVAL}" ]; then
     logthis "Devices ${NUM_DEVICES} : Size ${TOTAL_SIZE} : Used ${USED} : Available ${AVAILABLE} : Used% ${PCT_UTILIZATION}% : Threshold ${THRESHOLD}%"
     LOG_COUNT=0
   fi
-  THRESHOLD=$(calc_threshold)
   LOG_COUNT=$(expr $LOG_COUNT + 1 )
   sleep $DETECTION_INTERVAL
 done

--- a/config/ebs-autoscale.json
+++ b/config/ebs-autoscale.json
@@ -10,7 +10,7 @@
         "iops": 3000,
         "encrypted": 1
     },
-    "detection_interval": 1,
+    "detection_interval": 10,
     "limits": {
         "max_ebs_volume_size": 1500,
         "max_logical_volume_size": 8000,

--- a/config/ebs-autoscale.json
+++ b/config/ebs-autoscale.json
@@ -10,7 +10,7 @@
         "iops": 3000,
         "encrypted": 1
     },
-    "detection_interval": 10,
+    "detection_interval": 2,
     "limits": {
         "max_ebs_volume_size": 1500,
         "max_logical_volume_size": 8000,


### PR DESCRIPTION

*Description of changes:*
The current script when executed sends frequent DescribeVolume requests to the AWS API. When many nodes are doing the same the requests exceed the API limits.
The suggested version has a restructured ebs-autoscale script that limits the number of DescribeVolume requests. 
In our environment with typically 1000s of running batch nodes this script has been working well, however, I don't know if there are scenarios that it would not which we have not tested.
Thanks for considering.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
