### PR TITLE
Add random jitter to sleep

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -187,7 +187,7 @@ function create_and_attach_volume() {
             logthis "Could not determine the number of attached_volumes after $i attempts. Last response was: $attached_volumes"
             break
         fi
-        sleep $(( 2 ** i ))
+        sleep $(( 2 ** i + $RANDOM % 3))
     done
 
     local created_volumes=""
@@ -204,7 +204,7 @@ function create_and_attach_volume() {
             logthis "Could not determine the number of created_volumes after $i attempts. Last response was: $created_volumes"
             break
         fi
-        sleep $(( 2 ** i ))
+        sleep $(( 2 ** i + $RANDOM % 3))
     done
 
     local total_created_size=""
@@ -223,7 +223,7 @@ function create_and_attach_volume() {
             logthis "Could not determine the total_created_size after $i attempts. Last response was: $total_created_size"
             break
         fi
-        sleep $(( 2 ** i ))
+        sleep $(( 2 ** i + $RANDOM % 3))
     done
 
     # check how much EBS storage this instance has created
@@ -272,7 +272,7 @@ function create_and_attach_volume() {
           logthis "Could not create a volume after $i attempts. Last response was: $volume"
           break
       fi
-      sleep $(( 2 ** i ))
+      sleep $(( 2 ** i + $RANDOM % 3))
     done
 
     local volume_id=`echo $volume | jq -r '.VolumeId'`

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -87,7 +87,7 @@ get_num_devices() {
         break
       fi
 
-      sleep $(( 2 ** i ))
+      sleep $(( 2 ** i + $RANDOM %3 ))
   done
 
   echo "$attached_volumes"


### PR DESCRIPTION
*Description of changes:*
Add a random jitter of between 0 and 2 seconds to sleep. Large clusters of EC2 instances can become synchronous in attempts to make EC2 API calls exhausting the token pool. The jitter can spread the API calls. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
