### PR TITLE
Suggested for issue #33

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -168,7 +168,7 @@ function create_and_attach_volume() {
     instance_tags=$(
       aws ec2 describe-tags \
         --region $region \
-        --filters "Name=resource-id,Values=$instance_id" | jq -r .Tags | jq -c 'map({Key, Value})' | tr -d '[]"' | tr : =
+        --filters "Name=resource-id,Values=$instance_id" | jq -r .Tags | jq -c 'map({Key, Value})' | tr -d '[]"' | sed 's/{Key:/{Key=/g ; s/,Value:/,Value=/g ; s/{Key=aws:.*}//g ; s/,,/,/g ; s/,$//g ; s/^,//g'
       )
 
     local max_attempts=10


### PR DESCRIPTION
#33 Failure when Instance tags include colon (:)

Replace tr commend will multiple sed to keep colons in Keys and Values, remove aws: tags and orphan commas.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
