### PR TITLE
Add missing permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ In the above, we assume that the `MyInstanceProfileWithProperPermissions` EC2 In
                 "ec2:AttachVolume",
                 "ec2:DescribeVolumeStatus",
                 "ec2:DescribeVolumes",
+                "ec2:DescribeTags",
                 "ec2:ModifyInstanceAttribute",
                 "ec2:DescribeVolumeAttribute",
                 "ec2:CreateVolume",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The "ec2:DescribeTags" permission is required because of the `aws ec2 describe-tags` call on line 169 in `bin/create-ebs-volume`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
