### PR TITLE
Fixing instance tags parsing

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -168,7 +168,7 @@ function create_and_attach_volume() {
     instance_tags=$(
       aws ec2 describe-tags \
         --region $region \
-        --filters "Name=resource-id,Values=$instance_id" | jq -r .Tags | jq -c 'map({Key, Value})' | tr -d '[]"' | sed 's/{Key:/{Key=/g ; s/,Value:/,Value=/g ; s/{Key=aws.*}//g ; s/,,/,/g ; s/,$//g ; s/^,//g'
+        --filters "Name=resource-id,Values=$instance_id" | jq -r .Tags | jq -c 'map({Key, Value})' | tr -d '[]"' | sed 's/{Key:/{Key=/g ; s/,Value:/,Value=/g ; s/{Key=aws:[^}]*}//g ; s/,\{2,\}/,/g ; s/,$//g ; s/^,//g'
       )
 
     local max_attempts=10


### PR DESCRIPTION
1. Make parsing of aws tags less greedy
2. Instead of removing ',,', remov…e any sequence of two or more commas

*Description of changes:*
1. Specifically, changing `sed 's/{Key=aws.*}//g'` to `sed 's/{Key=aws[^}]*}//g'`. This ensures that if the first tag is an aws tag, the entire string (all following tags) are not removed.
2. `sed 's/,,/,/g'` to `sed 's/,\{2,\}/,/g'`. This will replace 2 or more commas with 1 comma. Fixes the issue where `,,,,` would be replaced with `,,`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
