### PR TITLE
Patch/get num devices

### DIFF
--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -64,7 +64,7 @@ get_num_devices() {
   # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
   # excluded as they aren't relevant to autoscaling
   local attached_volumes=""
-  local max_attempts=5
+  local max_attempts=${AWS_MAX_ATTEMPTS:-10}
 
   # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
   # eventually getting a usable value. The >= 0 test is really a test that we got an integer response

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -57,40 +57,8 @@ until [ -d "${MOUNTPOINT}" ]; do
 done
 
 get_num_devices() {
-  # This tag is added to all devices attached by this ebs-autoscale in the create-ebs-volume script it's presence indicates
-  # a device that has been added by auto-expansion rather than an EBS volume attached for other reasons or at startup.
-  TAG=amazon-ebs-autoscale-creation-time
-
-  # determine the number of devices attached by ebs-autoscale on this instance. Volumes attached in other ways are
-  # excluded as they aren't relevant to autoscaling
-  local attached_volumes=""
-  local max_attempts=${AWS_MAX_ATTEMPTS:-10}
-
-  # By waiting until the attached_volumes value is >=0 we will retry with backoff hopefully avoiding request limits
-  # eventually getting a usable value. The >= 0 test is really a test that we got an integer response
-  for i in $(eval echo "{0..$max_attempts}") ; do
-      local attached_volumes_response=""
-
-      attached_volumes_response=$(
-        aws ec2 describe-volumes \
-            --region $AWS_REGION \
-            --filters Name=attachment.instance-id,Values=$INSTANCE_ID Name=tag-key,Values=$TAG
-       )
-
-      attached_volumes=$(echo "$attached_volumes_response" | jq '.Volumes | length')
-      if [ "$attached_volumes" -ge 0 ]; then
-          break
-      fi
-
-      if [ $i -eq $max_attempts ] ; then
-        logthis "Could not determine the number of attached_volumes after $i attempts. Last response was: $attached_volumes_response"
-        break
-      fi
-
-      sleep $(( 2 ** i + $RANDOM %3 ))
-  done
-
-  echo "$attached_volumes"
+  # count the number of devices attached at `xvdb`
+  ls /dev/xvdb* 2> /dev/null | wc -l
 }
 
 calc_threshold() {
@@ -199,8 +167,8 @@ LOG_COUNT=$LOG_INTERVAL
 # time in seconds between event loops
 # keep this low so that rapid increases in utilization are detected
 DETECTION_INTERVAL=$(get_config_value .detection_interval)
-# get the number of devices once when the script first starts
-NUM_DEVICES=$(get_num_devices)
+# default to 1 since the install.sh script creates an initial volume 
+NUM_DEVICES=1
 THRESHOLD=$(calc_threshold "${NUM_DEVICES}")
 while true; do
 

--- a/config/ebs-autoscale.json
+++ b/config/ebs-autoscale.json
@@ -10,7 +10,7 @@
         "iops": 3000,
         "encrypted": 1
     },
-    "detection_interval": 2,
+    "detection_interval": 5,
     "limits": {
         "max_ebs_volume_size": 1500,
         "max_logical_volume_size": 8000,


### PR DESCRIPTION
This PR implements `get_num_devices` function using the local devices `/dev/` file system to prevent AWS API rate limits error
