### PR TITLE
Metadata service compatible with imdsv2

### DIFF
--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -261,7 +261,7 @@ function create_and_attach_volume() {
       # TagSpecifications[0].Tags[0] error to be thrown since the payload is determined to be a string, not dictionary.
       if [ ! -z $instance_tags ]; then
         local tag_specification="ResourceType=volume,Tags=[$instance_tags,{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
-      else:
+      else
         local tag_specification="ResourceType=volume,Tags=[{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
       fi
         

--- a/shared/utils.sh
+++ b/shared/utils.sh
@@ -28,10 +28,18 @@
 #  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 
+function get_metadata() {
+    local key=$1
+    local metdata_ip='169.254.169.254'
+    local token=$(curl -s -X PUT "http://$metdata_ip/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+    
+    echo `curl -s -H "X-aws-ec2-metadata-token: $token" http://$metdata_ip/latest/meta-data/$key`
+}
+
 function initialize() {
-    export AWS_AZ=$(curl -s  http://169.254.169.254/latest/meta-data/placement/availability-zone/)
+    export AWS_AZ=$(get_metadata placement/availability-zone)
     export AWS_REGION=$(echo ${AWS_AZ} | sed -e 's/[a-z]$//')
-    export INSTANCE_ID=$(curl -s  http://169.254.169.254/latest/meta-data/instance-id)
+    export INSTANCE_ID=$(get_metadata placement/availability-zone/instance-id)
     export EBS_AUTOSCALE_CONFIG_FILE=/etc/ebs-autoscale.json
 }
 
@@ -49,11 +57,6 @@ function get_config_value() {
     local filter=$1
 
     jq -r $filter $EBS_AUTOSCALE_CONFIG_FILE
-}
-
-function get_metadata() {
-    local key=$1
-    echo `curl -s http://169.254.169.254/latest/meta-data/$key`
 }
 
 function logthis() {

--- a/shared/utils.sh
+++ b/shared/utils.sh
@@ -39,7 +39,7 @@ function get_metadata() {
 function initialize() {
     export AWS_AZ=$(get_metadata placement/availability-zone)
     export AWS_REGION=$(echo ${AWS_AZ} | sed -e 's/[a-z]$//')
-    export INSTANCE_ID=$(get_metadata placement/availability-zone/instance-id)
+    export INSTANCE_ID=$(get_metadata instance-id)
     export EBS_AUTOSCALE_CONFIG_FILE=/etc/ebs-autoscale.json
 }
 


### PR DESCRIPTION
`imdsv2` is a required security standard. To achieve `imdsv2` compatibility, it is required to change the entire metadata service requests by adding a header with a token.
This fix is necessary since the EBS Autoscale service failed on an EC2 instance with a configured option of a required `http-tokens`:
```bash
aws ec2 modify-instance-metadata-options \
    --instance-id i-1234567898abcdef0 \
    --http-tokens required
```
*Source: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html*

*Description of changes:*
The `get_metadata` function changed and a request for a token was added before the metadata request itself. Also, all the metadata service requests are sent using the `get_metadata` function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
