### PR TITLE
imdsv2 and tags - fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon Elastic Block Store Autoscale
 
-This is an example of a daemon process that monitors a filesystem mountpoint and automatically expands it when free space falls below a configured threshold. New [Amazon EBS](https://aws.amazon.com/ebs/) volumes are added to the instance as necessary and the underlying filesystem ([BTRFS](http://btrfs.wiki.kernel.org) or [LVM](https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)) with [ext4](https://en.wikipedia.org/wiki/Ext4)) expands as new devices are added.
+This is an example of a daemon process that monitors a filesystem mountpoint and automatically expands it when free space falls below a configured threshold. New [Amazon EBS](https://aws.amazon.com/ebs/) volumes are added to the instance as necessary and the underlying filesystem ([BTRFS](http://btrfs.wiki.kernel.org) or [LVM](https://en.wikipedia.org/wiki/Logical_Volume_Manager_(Linux)) with [ext4](https://en.wikipedia.org/wiki/Ext4)) or [xfs](https://en.wikipedia.org/wiki/XFS)) expands as new devices are added.
 
 ## Assumptions:
 
@@ -53,9 +53,9 @@ Options
                         (Default: none - automatically create and attaches a volume)
                         If provided --initial-size is ignored.
 
-    -f, --file-system   btrfs | lvm.ext4
+    -f, --file-system   btrfs | lvm.ext4 | lvm.xfs
                         Filesystem to use (default: btrfs).
-                        Options are btrfs or lvm.ext4
+                        Options are btrfs, lvm.ext4, lvm.xfs
 
     -h, --help
                         Print help and exit.

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -170,14 +170,11 @@ function create_and_attach_volume() {
     local availability_zone=$(get_metadata placement/availability-zone)
     local region=${availability_zone%?}
 
-    local instance_tags=""
-    # Render instance tags to match: --tag-specification
-    # Output Example:
-    # {Key=Name,Value=Jenkins},{Key=Owner,Value=DevOps}
-    instance_tags=$(
+    # Find all non aws: instance tags
+    local instance_tags=$(
       aws ec2 describe-tags \
         --region $region \
-        --filters "Name=resource-id,Values=$instance_id" | jq -r .Tags | jq -c 'map({Key, Value})' | tr -d '[]"' | sed 's/{Key:/{Key=/g ; s/,Value:/,Value=/g ; s/{Key=aws:[^}]*}//g ; s/,\{2,\}/,/g ; s/,$//g ; s/^,//g'
+        --filters "Name=resource-id,Values=$instance_id" | jq -rc '.Tags | map({Key,Value} | select(.Key | test("^aws:") | not))'
       )
 
     local max_attempts=10
@@ -269,12 +266,8 @@ function create_and_attach_volume() {
     local volume=""
     for i in $(eval echo "{0..$max_attempts}") ; do
 
-      # The $instance_tags variable could be empty and will cause a TagSpecifications[0].Tags[0] error if
-      # it is passed as an empty value because it must be comma-separated from the other key-value pairs.
-      # Use a Shell Parameter Expansion to determine if the variable contains a value or not. If it has a value, 
-      # append a comma at the end so the aws cli syntax is compliant when it is subbed into the tag_specification variable.
-      local instance_tags=${instance_tags:+${instance_tags},}
-      local tag_specification="ResourceType=volume,Tags=[$instance_tags{Key=source-instance,Value=$instance_id},{Key=amazon-ebs-autoscale-creation-time,Value=$timestamp}]"
+      local ebs_autoscale_tags='[{"Key":"source-instance","Value":"'$instance_id'"},{"Key":"amazon-ebs-autoscale-creation-time","Value":"'$timestamp'"}]'
+      local tag_specifications='[{"ResourceType":"volume","Tags":'$(jq -sc 'add' <(echo "$ebs_autoscale_tags") <(echo "$instance_tags"))'}]'
 
       # Note: Shellcheck says the $vars in this command should be double quoted to prevent globbing and word-splitting,
       # but this ends up making the '--encrypted' argument to fail during the execution of the install script. Conversely, NOT putting double-quotes
@@ -285,7 +278,7 @@ function create_and_attach_volume() {
               --region $region \
               --availability-zone $availability_zone \
               $volume_opts \
-              --tag-specification "$tag_specification" \
+              --tag-specifications "$tag_specifications" \
           2> $tmpfile
       )
 

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -268,7 +268,7 @@ function create_and_attach_volume() {
     local volume=""
     for i in $(eval echo "{0..$max_attempts}") ; do
 
-      local ebs_autoscale_tags='[{"Key":"source-instance","Value":"'$instance_id'"},{"Key":'$TAG'","Value":"'$timestamp'"}]'
+      local ebs_autoscale_tags='[{"Key":"source-instance","Value":"'$instance_id'"},{"Key":"'$TAG'","Value":"'$timestamp'"}]'
       local tag_specifications='[{"ResourceType":"volume","Tags":'$(jq -sc 'add' <(echo "$ebs_autoscale_tags") <(echo "$instance_tags"))'}]'
 
       # Note: Shellcheck says the $vars in this command should be double quoted to prevent globbing and word-splitting,

--- a/bin/create-ebs-volume
+++ b/bin/create-ebs-volume
@@ -46,10 +46,10 @@ Options
 
     -t, --type          Type of volume. (Default: config.volume.type)
 
-    -i, --iops          N 
+    -i, --iops          N
                         IOPS for volume. Only valid if type=io1, io2, gp3. (Default: config.volume.iops)
 
-    --throughput        N 
+    --throughput        N
                         The throughput for a volume, with a maximum of 1,000 MiB/s. (Default: config.volume.throughput)
 
     --not-encrypted     Flag to make the volume un-encyrpted. Default is to create
@@ -58,11 +58,11 @@ Options
     --max-total-created-size SIZE_GB
                         Maximum total size in GB of all volumes created by the instance.
                         (Default: config.limits.max_logical_volume_size)
-                        
+
     --max-attached-volumes N
                         Maximum number of attached volumes.
                         (Default: config.limits.max_ebs_volume_count)
-    
+
     --max-created-volumes N
                         Maximum number of volumes that can be created by the instance.
                         (Default: MAX_ATTACHED_VOLUMES)
@@ -166,6 +166,8 @@ function get_next_logical_device() {
 }
 
 function create_and_attach_volume() {
+    TAG=amazon-ebs-autoscale-creation-time
+
     local instance_id=$(get_metadata instance-id)
     local availability_zone=$(get_metadata placement/availability-zone)
     local region=${availability_zone%?}
@@ -184,7 +186,7 @@ function create_and_attach_volume() {
         attached_volumes=$(
           aws ec2 describe-volumes \
             --region $region \
-            --filters "Name=attachment.instance-id,Values=$instance_id"
+            --filters Name=attachment.instance-id,Values=$instance_id Name=tag-key,Values=$TAG
         )
 
         if [ $? -eq 0 ]; then
@@ -201,7 +203,7 @@ function create_and_attach_volume() {
         created_volumes=$(
             aws ec2 describe-volumes \
                 --region $region \
-                --filters "Name=tag:source-instance,Values=$instance_id"
+                --filters Name=attachment.instance-id,Values=$instance_id Name=tag-key,Values=$TAG
         )
 
         if [ $? -eq 0 ]; then
@@ -218,7 +220,7 @@ function create_and_attach_volume() {
         total_created_size=$(
             aws ec2 describe-volumes \
                 --region $region \
-                --filters "Name=tag:source-instance,Values=$instance_id" \
+                --filters Name=attachment.instance-id,Values=$instance_id Name=tag-key,Values=$TAG \
                 --query 'sum(Volumes[].Size)' \
                 --output text
         )
@@ -246,7 +248,7 @@ function create_and_attach_volume() {
     if [ "`echo $attached_volumes | jq '.Volumes | length'`" -ge "$MAX_ATTACHED_VOLUMES" ]; then
         error "maximum number of attached volumes reached ($MAX_ATTACHED_VOLUMES)"
     fi
-    
+
     # check if there are available device names
     local device=$(get_next_logical_device)
     if [ -z "$device" ]; then
@@ -266,7 +268,7 @@ function create_and_attach_volume() {
     local volume=""
     for i in $(eval echo "{0..$max_attempts}") ; do
 
-      local ebs_autoscale_tags='[{"Key":"source-instance","Value":"'$instance_id'"},{"Key":"amazon-ebs-autoscale-creation-time","Value":"'$timestamp'"}]'
+      local ebs_autoscale_tags='[{"Key":"source-instance","Value":"'$instance_id'"},{"Key":'$TAG'","Value":"'$timestamp'"}]'
       local tag_specifications='[{"ResourceType":"volume","Tags":'$(jq -sc 'add' <(echo "$ebs_autoscale_tags") <(echo "$instance_tags"))'}]'
 
       # Note: Shellcheck says the $vars in this command should be double quoted to prevent globbing and word-splitting,
@@ -324,7 +326,7 @@ function create_and_attach_volume() {
         --instance-id $instance_id \
         --volume-id $volume_id \
     > /dev/null
-    
+
     status="$?"
     if [ ! "$status" -eq 0 ]; then
         logthis "deleting volume $volume_id"
@@ -332,7 +334,7 @@ function create_and_attach_volume() {
             --region $region \
             --volume-id $volume_id \
         > /dev/null
-        
+
         error "could not attach volume to instance"
     fi
     set -e

--- a/bin/ebs-autoscale
+++ b/bin/ebs-autoscale
@@ -172,11 +172,16 @@ add_space () {
         logthis "Adding device ${DEVICE} to logical volume ${MOUNTPOINT}"
         btrfs device add ${DEVICE} ${MOUNTPOINT}
         btrfs balance start -m ${MOUNTPOINT}
-      else
-        logthis "Adding device ${DEVICE} to logical volume /dev/mapper/${LVM_VG}-${LVM_LV}"
+      elif [[ "$FILE_SYSTEM" =~ ^lvm\.(ext4|xfs)$ ]]; then
+        device_path="/dev/mapper/${LVM_VG}-${LVM_LV}"
+        logthis "Adding device ${DEVICE} to logical volume ${device_path}"
         vgextend ${LVM_VG} ${DEVICE}
-        lvresize -l 100%VG /dev/mapper/${LVM_VG}-${LVM_LV}
-        resize2fs /dev/mapper/${LVM_VG}-${LVM_LV}
+        lvresize -l 100%VG ${device_path}
+        [ "${FILE_SYSTEM}" = "lvm.ext4" ] && resize2fs ${device_path}
+        [ "${FILE_SYSTEM}" = "lvm.xfs" ] && xfs_growfs ${device_path}
+      else
+        echo "Unknown file system type: ${FILE_SYSTEM}"
+        exit 1
       fi
       logthis "Finished extending logical volume"
 

--- a/config/ebs-autoscale.json
+++ b/config/ebs-autoscale.json
@@ -1,6 +1,7 @@
 {
     "mountpoint": "%%MOUNTPOINT%%",
     "filesystem": "%%FILESYSTEM%%",
+    "imdsv2": "%%IMDSV2%%",
     "lvm": {
         "volume_group": "autoscale_vg",
         "logical_volume": "autoscale_lv"

--- a/install.sh
+++ b/install.sh
@@ -185,6 +185,21 @@ done
 
 eval set -- "$PARAMS"
 
+# install default config
+cat ${BASEDIR}/config/ebs-autoscale.json | \
+  sed -e "s#%%MOUNTPOINT%%#${MOUNTPOINT}#" | \
+  sed -e "s#%%VOLUMETYPE%%#${VOLUMETYPE}#" | \
+  sed -e "s#%%VOLUMEIOPS%%#${VOLUMEIOPS}#" | \
+  sed -e "s#%%VOLUMETHOUGHPUT%%#${VOLUMETHOUGHPUT}#" | \
+  sed -e "s#%%FILESYSTEM%%#${FILE_SYSTEM}#" | \
+  sed -e "s#%%IMDSV2%%#${IMDSV2}#" | \
+  sed -e "s#%%MINEBSVOLUMESIZE%%#${MIN_EBS_VOLUME_SIZE}#" | \
+  sed -e "s#%%MAXEBSVOLUMESIZE%%#${MAX_EBS_VOLUME_SIZE}#" | \
+  sed -e "s#%%MAXLOGICALVOLUMESIZE%%#${MAX_LOGICAL_VOLUME_SIZE}#" | \
+  sed -e "s#%%MAXATTACHEDVOLUMES%%#${MAX_ATTACHED_VOLUMES}#" | \
+  sed -e "s#%%INITIALUTILIZATIONTHRESHOLD%%#${INITIAL_UTILIZATION_THRESHOLD}#" \
+  > /etc/ebs-autoscale.json
+
 initialize
 
 # for backwards compatibility evaluate positional parameters like previous 2.0.x and 2.1.x releases
@@ -213,20 +228,6 @@ cp ${BASEDIR}/shared/utils.sh /usr/local/amazon-ebs-autoscale/shared
 ## Install configs
 # install the logrotate config
 cp ${BASEDIR}/config/ebs-autoscale.logrotate /etc/logrotate.d/ebs-autoscale
-
-# install default config
-cat ${BASEDIR}/config/ebs-autoscale.json | \
-  sed -e "s#%%MOUNTPOINT%%#${MOUNTPOINT}#" | \
-  sed -e "s#%%VOLUMETYPE%%#${VOLUMETYPE}#" | \
-  sed -e "s#%%VOLUMEIOPS%%#${VOLUMEIOPS}#" | \
-  sed -e "s#%%VOLUMETHOUGHPUT%%#${VOLUMETHOUGHPUT}#" | \
-  sed -e "s#%%FILESYSTEM%%#${FILE_SYSTEM}#" | \
-  sed -e "s#%%MINEBSVOLUMESIZE%%#${MIN_EBS_VOLUME_SIZE}#" | \
-  sed -e "s#%%MAXEBSVOLUMESIZE%%#${MAX_EBS_VOLUME_SIZE}#" | \
-  sed -e "s#%%MAXLOGICALVOLUMESIZE%%#${MAX_LOGICAL_VOLUME_SIZE}#" | \
-  sed -e "s#%%MAXATTACHEDVOLUMES%%#${MAX_ATTACHED_VOLUMES}#" | \
-  sed -e "s#%%INITIALUTILIZATIONTHRESHOLD%%#${INITIAL_UTILIZATION_THRESHOLD}#" \
-  > /etc/ebs-autoscale.json
 
 ## Create filesystem
 if [ -e $MOUNTPOINT ] && ! [ -d $MOUNTPOINT ]; then

--- a/shared/utils.sh
+++ b/shared/utils.sh
@@ -32,19 +32,19 @@ function get_metadata() {
     local key=$1
     local metadata_ip='169.254.169.254'
 
-    if [ ! -z "$IMDSV2" ]; then
+    if [ ! -z "$(get_config_value .imdsv2)" ]; then
         local token=$(curl -s -X PUT "http://$metadata_ip/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
         local token_wrapper='-H "X-aws-ec2-metadata-token: $token"'
     fi
     
-    echo `curl -s $token_wrapper http://$metadata_ip/latest/meta-data/$key`
+    eval "curl -s $token_wrapper http://$metadata_ip/latest/meta-data/$key"
 }
 
 function initialize() {
+    export EBS_AUTOSCALE_CONFIG_FILE=/etc/ebs-autoscale.json
     export AWS_AZ=$(get_metadata placement/availability-zone)
     export AWS_REGION=$(echo ${AWS_AZ} | sed -e 's/[a-z]$//')
     export INSTANCE_ID=$(get_metadata instance-id)
-    export EBS_AUTOSCALE_CONFIG_FILE=/etc/ebs-autoscale.json
 }
 
 function detect_init_system() {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -42,9 +42,8 @@ for volume in $attached_volumes; do
     aws ec2 detach-volume --region $region --volume-id $volume
     aws ec2 wait volume-available --region $region --volume-ids $volume
     echo "volume $volume detached"
-    
+
     aws ec2 delete-volume --region $region --volume-id $volume
     aws ec2 wait volume-deleted --region $region --volume-ids $volume
-    echo "volume $volume deleted"  
+    echo "volume $volume deleted"
 done
-


### PR DESCRIPTION
Some fixes are suggested:
1. Referring to the new `imdsv2` feature, a few critical bugs require the fixes listed below.
2. Reordering the tags handling to support any pattern of tags' keys and values.

Description of changes:
1. `IMDSV2` value is stored in the config file instead of a temporary environment variable.
2. The config file rendering part moved before the `initialize` function calling to allow the function to use the `IMDSV2` config parameter.
3. Using `eval` instead of `echo` in the `get_metadata()` function.
4. Separation between instance tags and ebs autoscale tags.
5. Changing the way that the `resource-id` tag is added.
6. Changing the `--tag-specification` tag to `--tag-specifications`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.